### PR TITLE
Fix probability drift across workloads and eliminate rare assert(false) in DiscreteGenerator

### DIFF
--- a/core/core_workload.cc
+++ b/core/core_workload.cc
@@ -105,6 +105,8 @@ void CoreWorkload::InitLoadWorkload(const utils::Properties &p, unsigned int nth
 
 
 void CoreWorkload::InitRunWorkload(const utils::Properties &p, unsigned int nthreads, unsigned int this_thread) {
+  op_chooser_.Reset();
+
   generator_.seed(this_thread * 3423452437 + 8349344563457);
 
   double read_proportion = std::stod(p.GetProperty(READ_PROPORTION_PROPERTY,

--- a/core/core_workload.cc
+++ b/core/core_workload.cc
@@ -147,6 +147,8 @@ void CoreWorkload::InitRunWorkload(const utils::Properties &p, unsigned int nthr
   if (readmodifywrite_proportion > 0) {
     op_chooser_.AddValue(READMODIFYWRITE, readmodifywrite_proportion);
   }
+
+  op_chooser_.UpdateGenerator();
   
   if (request_dist == "uniform") {
     key_chooser_ = new UniformGenerator(generator_, 0, record_count_ - 1);

--- a/core/discrete_generator.h
+++ b/core/discrete_generator.h
@@ -23,6 +23,7 @@ class DiscreteGenerator : public Generator<Value> {
  public:
   DiscreteGenerator(std::default_random_engine &gen) : generator_(gen), dist_(0.0, 1.0), sum_(0) { }
   void AddValue(Value value, double weight);
+  void Reset();
 
   Value Next();
   Value Last() { return last_; }
@@ -40,8 +41,14 @@ inline void DiscreteGenerator<Value>::AddValue(Value value, double weight) {
   if (values_.empty()) {
     last_ = value;
   }
-  values_.push_back(std::make_pair(value, weight));
-  sum_ += weight;
+
+template <typename Value>
+inline void DiscreteGenerator<Value>::Reset() {
+  values_.clear();
+  sum_ = 0;
+  last_ = Value();
+}
+
 }
 
 template <typename Value>

--- a/core/discrete_generator.h
+++ b/core/discrete_generator.h
@@ -16,23 +16,28 @@
 #include <random>
 #include "utils.h"
 
+// Scale factor for the discrete generator, used to convert weights to integers.
+//   higher scale factor allows for more precision in weights
+#define SCALE 1000000000  // 1'000'000'000
+
 namespace ycsbc {
 
 template <typename Value>
 class DiscreteGenerator : public Generator<Value> {
  public:
-  DiscreteGenerator(std::default_random_engine &gen) : generator_(gen), dist_(0.0, 1.0), sum_(0) { }
+  DiscreteGenerator(std::default_random_engine &gen) : generator_(gen), dist_(0, SCALE - 1), sum_(0) { }
   void AddValue(Value value, double weight);
   void Reset();
+  void UpdateGenerator();
 
   Value Next();
   Value Last() { return last_; }
 
  private:
   std::default_random_engine &generator_;
-  std::uniform_real_distribution<float> dist_;
-  std::vector<std::pair<Value, double>> values_;
-  double sum_;
+  std::uniform_int_distribution<uint32_t> dist_;
+  std::vector<std::pair<Value, uint32_t>> values_;
+  uint32_t sum_;
   Value last_;
 };
 
@@ -42,6 +47,12 @@ inline void DiscreteGenerator<Value>::AddValue(Value value, double weight) {
     last_ = value;
   }
 
+  uint32_t iw = static_cast<uint32_t>(std::lround(weight * SCALE));
+  assert(iw > 0);
+  values_.push_back(std::make_pair(value, iw));
+  sum_ += iw;
+}
+
 template <typename Value>
 inline void DiscreteGenerator<Value>::Reset() {
   values_.clear();
@@ -49,17 +60,23 @@ inline void DiscreteGenerator<Value>::Reset() {
   last_ = Value();
 }
 
+// Update the distribution range based on the sum of weights
+//   should be called after adding all values
+template <typename Value>
+inline void DiscreteGenerator<Value>::UpdateGenerator() {
+  assert(sum_ > 0);
+  dist_ = std::uniform_int_distribution<uint32_t>(0, sum_ - 1);
 }
 
 template <typename Value>
 inline Value DiscreteGenerator<Value>::Next() {
-  double chooser = dist_(generator_);
+  uint32_t chooser = dist_(generator_);
 
   for (auto p = values_.cbegin(); p != values_.cend(); ++p) {
-    if (chooser < p->second / sum_) {
+    if (chooser < p->second) {
       return last_ = p->first;
     }
-    chooser -= p->second / sum_;
+    chooser -= p->second;
   }
   
   assert(false);


### PR DESCRIPTION
**1. Reset ```op_chooser_``` before a new workload starts**

Currently, CoreWorkload is reused across load and other workloads. However, the ```CoreWorkload:op_chooser_``` is not reset between each workload. Because the container was never cleared, the weights from each workload kept accumulating (A → B → C → …), distorting the operation mix for later workloads.

This PR adds a ```Reset()``` function in DiscreteGenerator to clear the values vector, letting each workload starts with a clean state and call it at ```CoreWorkload::InitRunWorkload()```

**2. Promote the RNG distribution from float to double**

Current DiscreteGenerator uses ```std::uniform_real_distribution<double> dist_``` to generate a value beteween [0.0, 1.0). 
During large workload runs (e.g. 10 million ops), it occasionally returned exactly 1.0. This will lead to the assertion failure at this line:

https://github.com/rtjohnso/YCSB-C/blob/0d5825c92e6d7e567408a0596a3d49f2ef63f312/core/discrete_generator.h#L58

The assertion failure is because this for loop cannot find a bucket for chooser == 1.0.
https://github.com/rtjohnso/YCSB-C/blob/0d5825c92e6d7e567408a0596a3d49f2ef63f312/core/discrete_generator.h#L52

Cause:

The underlying engine (```std::default_random_engine```) is defined as in gcc/libstdc++ (https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/random.h#L1694C38-L1694C51):
```
typedef linear_congruential_engine<uint_fast32_t, 16807UL, 0UL, 2147483647UL>
  minstd_rand0;
```
The RNG sometimes returns its maximum 32-bit integer value. However, converting that 32-bit int to a float loses precision and forces it to round up; the numerator and denominator round to the same float, so the final output value turns exactly 1.0.

**Solution:**
Switch to integer sampling. 

What Changed:
1. Integer weights
```AddValue()``` now converts each double weight to a fixed-point integer. ```values_```, ```sum_```, and ```chooser``` are all uint32_t.

2. RNG range
```UpdateGenerator()``` is called after all ```AddValue()``` finishes in ```CoreWorkload::InitRunWorkload()``` to set the range of the RNG to ```[0, sum_ - 1]```, where sum_ is the current total weight.

3. Sampling loop
```Next()``` now compares chooser directly to each bucket’s integer weight and subtracts—no divisions.
